### PR TITLE
Readd the Theme Customizer functionality

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -7,7 +7,9 @@
 ?>
 
 	<footer>
-		
+		<div class="site-info">
+			<?php echo get_theme_mod( 'site-info' ); ?>
+		</div>
 	</footer>
 </div>
 

--- a/functions.php
+++ b/functions.php
@@ -157,3 +157,7 @@ require get_template_directory() . '/inc/extras.php';
  */
 require get_template_directory() . '/inc/jetpack.php';
 
+/**
+ * Customizer additions.
+ */
+require get_template_directory() . '/inc/customizer.php';

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * boiler Theme Customizer
+ *
+ * @package boiler
+ */
+
+/**
+ * Add postMessage support for site title and description for the Theme Customizer.
+ *
+ * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ */
+function boiler_customize_register( $wp_customize ) {
+	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
+	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
+}
+add_action( 'customize_register', 'boiler_customize_register' );
+
+/**
+ * Add site info to footer
+ */
+function boiler_customize_site_info( $wp_customize ) {
+	// First thing is to add a secion
+	$wp_customize->add_section( 'site_info_section', array(
+		'title' => __( 'Site Info', '_s' ),
+		'priority' => '35',
+		'description' => __( 'The label and text for the phone number', '_s' )
+	) );
+
+	// Add a setting that will be customizable
+	$wp_customize->add_setting( 'site_info', array(
+		'default' => 'Site Info',
+		'transport' => 'postMessage'
+	) );
+
+	// Add a control to bind the setting to the section
+	$wp_customize->add_control( 'site_info', array(
+		'label' => __('Site Info', '_s' ),
+		'section' => 'site_info_section',
+		'type' => 'text'
+	) );
+}
+add_action( 'customize_register', 'boiler_customize_site_info' );
+
+/**
+ * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+function boiler_customize_preview_js() {
+	wp_enqueue_script( 'boiler_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20130508', true );
+}
+add_action( 'customize_preview_init', 'boiler_customize_preview_js' );

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -1,0 +1,27 @@
+/**
+ * Theme Customizer enhancements for a better user experience.
+ *
+ * Contains handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+
+( function( $ ) {
+	// Site title and description.
+	wp.customize( 'blogname', function( value ) {
+		value.bind( function( to ) {
+			$( '.site-title a' ).text( to );
+		} );
+	} );
+	wp.customize( 'blogdescription', function( value ) {
+		value.bind( function( to ) {
+			$( '.site-description' ).text( to );
+		} );
+	} );
+
+	// Custom control definded in customizer.php
+	// This will make sure it updates in real time
+	wp.customize( 'site_info', function( value ) {
+		value.bind( function( to ) {
+			$('.site-info').text( to );
+		} );
+	} );
+} )( jQuery );


### PR DESCRIPTION
I updated/added four files.

footer.php - I just added the echo to get whatever field we wanted.  The class name used in the wrapper is also used in the JS for the live reload thing.

functions.php - I just added the call to the file

customizer.php - I left the code in for the default ones (theme title/description).  I think they're handled differently than other options.  I removed all reference to the header color.  The action is made of 3 parts.  Creating a section, creating a setting, and binding the setting to the section.  A section can have multiple settings in it.

customizer.js - I just dropped this into the root of the JS stuff, not sure how you're doing scripting for one off things.  This just grabs the value that the user puts in the text field and live reloads it on the customize page.
